### PR TITLE
chore: bump Alpine versions

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10.0-alpine3.18
+FROM node:20.10.0-alpine3.19
 
 LABEL org.opencontainers.image.authors matijs <matijs@gmail.com>
 LABEL org.opencontainers.image.source https://github.com/matijs/dockerfiles/blob/main/npm/Dockerfile

--- a/pnpm/Dockerfile
+++ b/pnpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10.0-alpine
+FROM node:20.10.0-alpine3.19
 
 LABEL org.opencontainers.image.authors matijs <matijs@gmail.com>
 LABEL org.opencontainers.image.source https://github.com/matijs/dockerfiles/blob/main/pnpm/Dockerfile

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.10.0-alpine
+FROM node:20.10.0-alpine3.19
 
 LABEL org.opencontainers.image.authors matijs <matijs@gmail.com>
 LABEL org.opencontainers.image.source https://github.com/matijs/dockerfiles/blob/main/yarn/Dockerfile


### PR DESCRIPTION
Alpine Linux 3.19 was released and official NodeJS containers have been updated.