### PR TITLE
chore: bump alpine versions

### DIFF
--- a/npm/Dockerfile
+++ b/npm/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.13.1-alpine3.19
+FROM node:20.13.1-alpine3.20
 
 LABEL org.opencontainers.image.authors matijs <matijs@gmail.com>
 LABEL org.opencontainers.image.source https://github.com/matijs/dockerfiles/blob/main/npm/Dockerfile

--- a/pnpm/Dockerfile
+++ b/pnpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.13.1-alpine3.19
+FROM node:20.13.1-alpine3.20
 
 LABEL org.opencontainers.image.authors matijs <matijs@gmail.com>
 LABEL org.opencontainers.image.source https://github.com/matijs/dockerfiles/blob/main/pnpm/Dockerfile

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.13.1-alpine3.19
+FROM node:20.13.1-alpine3.20
 
 LABEL org.opencontainers.image.authors matijs <matijs@gmail.com>
 LABEL org.opencontainers.image.source https://github.com/matijs/dockerfiles/blob/main/yarn/Dockerfile


### PR DESCRIPTION
Alpine Linux 3.20 was releases and a few vulnerabilities have been resolve.