### PR TITLE
chore: simplify dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: "docker"
-    directory: "/npm"
-    schedule:
-      interval: "weekly"
-      day: "saturday"
-    ignore:
-      - dependency-name: "node"
-        update-types:
-          - "version-update:semver-major"
-
-  - package-ecosystem: "docker"
-    directory: "/pnpm"
-    schedule:
-      interval: "weekly"
-      day: "saturday"
-    ignore:
-      - dependency-name: "node"
-        update-types:
-          - "version-update:semver-major"
-
-  - package-ecosystem: "docker"
-    directory: "/yarn"
+    directories:
+      - "/npm"
+      - "/pnpm"
+      - "/yarn"
     schedule:
       interval: "weekly"
       day: "saturday"


### PR DESCRIPTION
Use directories for Docker updates instead of repeating the same ecosystem three times