### PR TITLE
chore: bump versions

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.17.1-alpine3.21
+FROM node:22.18.0-alpine3.22
 
 LABEL org.opencontainers.image.authors="matijs <matijs@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/matijs/dockerfiles/blob/main/nodejs/Dockerfile"


### PR DESCRIPTION
- Node.js from 22.17.1 to 22.18.0
- Alpine Linux from 3.21 to 3.22